### PR TITLE
remove php context closing tag

### DIFF
--- a/inc/missing-php-functions.php
+++ b/inc/missing-php-functions.php
@@ -73,6 +73,3 @@ if( version_compare( $GLOBALS['wp_version'], '4.4.0' , '<' ) ){
     }
 
 }
-
-
-?>


### PR DESCRIPTION
?> closing tag causes
Warning: Cannot modify header information - headers already sent by (./wp-content/plugins/woocommerce-multilingual/inc/missing-php-functions.php)