### PR TITLE
FO Quick view Ajax queries need converted price

### DIFF
--- a/inc/currencies/class-wcml-multi-currency.php
+++ b/inc/currencies/class-wcml-multi-currency.php
@@ -148,7 +148,7 @@ class WCML_Multi_Currency{
     private function _load_filters(){
         $load = false;
 
-        if(!is_admin() && $this->get_client_currency() != get_option('woocommerce_currency')){
+        if(( !is_admin() || ( defined('DOING_AJAX') && DOING_AJAX ) ) && $this->get_client_currency() != get_option('woocommerce_currency')){
             $load = true;
         }else{
             if(is_ajax() && $this->get_client_currency() != get_option('woocommerce_currency')){


### PR DESCRIPTION
Without the test "( defined('DOING_AJAX') && DOING_AJAX ) )" price for products "quick views" and catalog "order by" ajax query don't get the price in the current currency but in the default currency.